### PR TITLE
Removing max, min, and sort from ResponseCollection

### DIFF
--- a/lib/vindicia/response/collection.rb
+++ b/lib/vindicia/response/collection.rb
@@ -1,9 +1,10 @@
 module Vindicia::Response
   class Collection < Base
     extend Forwardable
-    def_delegators :body, :each
-
     include Enumerable
+
+    def_delegators :body, :each
+    undef_method :min, :max, :sort
 
     def total_count
       raw_body['total_count']

--- a/spec/unit/response/collection_spec.rb
+++ b/spec/unit/response/collection_spec.rb
@@ -28,4 +28,8 @@ describe 'instance methods' do
 
   it { is_expected.to delegate_method(:each).to(:body) }
   it { is_expected.to be_an(Enumerable) }
+
+  it { is_expected.not_to respond_to(:min) }
+  it { is_expected.not_to respond_to(:max) }
+  it { is_expected.not_to respond_to(:sort) }
 end


### PR DESCRIPTION
the Enumerable mixin gives ResponseCollection a lot of power. However, #min, #max, and #sort aren't powers it should have. This PR removes those.